### PR TITLE
Set origin header in socket.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ npm install
 
 Run the server on localhost:
 ```sh
-node routes/index.js
+DEV=true node routes/index.js
 ```
 
 ## Release History

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ npm install
 
 Run the server on localhost:
 ```sh
-DEV=true node routes/index.js
+node routes/index.js
 ```
 
 ## Release History

--- a/routes/index.js
+++ b/routes/index.js
@@ -2,17 +2,19 @@ const app = require("express")();
 const http = require("http").Server(app);
 
 
+const allowAll = (req, callback) => {
+	callback(null, true);
+}
+
+const allowProd = (req, callback) => {
+	callback(null, req.headers.origin === 'http://letsgetfuckedup.patrice.codes')
+}
+
 const io = require("socket.io")(http, {
 	pingInterval: 4000,
 	pingTimeout: 5000,
+	allowRequest: process.env.DEV? allowAll : allowProd,
 });
-
-if (process.env.DEV) {
-	io.origins("http://localhost:5000");
-}
-else {
-	io.origins("http://letsgetfuckedup.patrice.codes");
-}
 
 const gameMap = new Map();
 

--- a/routes/index.js
+++ b/routes/index.js
@@ -2,18 +2,10 @@ const app = require("express")();
 const http = require("http").Server(app);
 
 
-const allowAll = (req, callback) => {
-	callback(null, true);
-}
-
-const allowProd = (req, callback) => {
-	callback(null, req.headers.origin === 'http://letsgetfuckedup.patrice.codes')
-}
-
 const io = require("socket.io")(http, {
 	pingInterval: 4000,
 	pingTimeout: 5000,
-	allowRequest: process.env.DEV? allowAll : allowProd,
+	allowRequest: (req, callback) => callback(null, true),
 });
 
 const gameMap = new Map();

--- a/routes/index.js
+++ b/routes/index.js
@@ -6,6 +6,14 @@ const io = require("socket.io")(http, {
 	pingInterval: 4000,
 	pingTimeout: 5000,
 });
+
+if (process.env.DEV) {
+	io.origins("http://localhost:5000");
+}
+else {
+	io.origins("http://letsgetfuckedup.patrice.codes");
+}
+
 const gameMap = new Map();
 
 const cards = {};


### PR DESCRIPTION
Allow any origin and set the `Access-Control-Allow-Origin` header accordingly. E.g.:
```
> Origin: http://localhost:5000
< Access-Control-Allow-Credentials: true
< Access-Control-Allow-Origin: http://localhost:5000
```

This was more cumbersome than I expected...

More secure alternative:
Set the `Access-Control-Allow-Origin` header to the frontend url. Socket.io then directly blocks requests that do not contain the correct `Origin` header. This may lead to problems in app deployments. May also lead to hard-coded urls or more complexity for the deployment...

Socket.io CORS documentation: https://socket.io/docs/v2/handling-cors/ (but not everything works as documented)